### PR TITLE
bump onesdk version

### DIFF
--- a/frontend-onesdk-sample-angular-vite/package.json
+++ b/frontend-onesdk-sample-angular-vite/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^17.3.0",
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "1.7.15",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"

--- a/frontend-onesdk-sample-angular-webpack/package.json
+++ b/frontend-onesdk-sample-angular-webpack/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^16.2.0",
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "1.7.15",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"

--- a/frontend-onesdk-sample-nextjs-webpack/package.json
+++ b/frontend-onesdk-sample-nextjs-webpack/package.json
@@ -11,7 +11,7 @@
     "start:localServer": "npx http-server -p 8080"
   },
   "dependencies": {
-    "@frankieone/one-sdk": "^1.7.6",
+    "@frankieone/one-sdk": "^1.7.15",
     "kill-port": "^2.0.1",
     "next": "14.2.5",
     "react": "^18",

--- a/frontend-onesdk-sample-react-vite/package.json
+++ b/frontend-onesdk-sample-react-vite/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@frankieone/one-sdk": "1.7.6"
+    "@frankieone/one-sdk": "1.7.15"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/frontend-onesdk-sample-react-webpack/package.json
+++ b/frontend-onesdk-sample-react-webpack/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "1.7.15",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend-onesdk-sample-vanilla-react-webpack/package.json
+++ b/frontend-onesdk-sample-vanilla-react-webpack/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "1.7.15",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/frontend-onesdk-sample-vue-vite/package.json
+++ b/frontend-onesdk-sample-vue-vite/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "1.7.15",
     "vue": "^3.4.29",
     "vue-router": "^4.4.0"
   },

--- a/frontend-onesdk-sample-vue-webpack/package.json
+++ b/frontend-onesdk-sample-vue-webpack/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "1.7.15",
     "core-js": "^3.8.3",
     "vue": "^3.2.13",
     "vue-router": "^4.4.0"


### PR DESCRIPTION
**Context**


**Problem**


**Solution**


**Testing Notes**


**PR Review Guidelines**
- [ ] Unit tests are added/updated
- [ ] System/Integration tests are added/updated
- [ ] Acceptance criteria is validated locally 
 
 **PR Summary by Typo**
------------

**Overview**
This PR updates the `@frankieone/one-sdk` dependency across all sample code projects (Angular, Next.js, React, Vue) from version 1.7.6 to 1.7.15.  The PR description lacks details regarding the reason for the version bump.

**Key Changes**
- The `@frankieone/one-sdk` dependency version is updated to 1.7.15 in all `package.json` files.

**Recommendations**
Request clarification from the author on the specific changes included in the OneSDK version 1.7.15 update and the reasons for the upgrade. Verify the functionality of all sample applications after merging.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>