### PR TITLE
chore(mobile): remove platform permission request handler in Flutter WebView

### DIFF
--- a/mobile-onesdk-sample-android/app/src/main/java/com/frankieone/onesdk/sample/WebViewActivity.kt
+++ b/mobile-onesdk-sample-android/app/src/main/java/com/frankieone/onesdk/sample/WebViewActivity.kt
@@ -64,6 +64,7 @@ class WebViewActivity : AppCompatActivity() {
     }
 
     private fun setupWebView() {
+        WebView.setWebContentsDebuggingEnabled(true)
         binding.webView.settings.apply {
             javaScriptEnabled = true
             domStorageEnabled = true

--- a/mobile-onesdk-sample-expo/src/WebViewScreen.tsx
+++ b/mobile-onesdk-sample-expo/src/WebViewScreen.tsx
@@ -101,6 +101,7 @@ export default function WebViewScreen({ route, navigation }: Props) {
         allowsInlineMediaPlayback
         mediaPlaybackRequiresUserAction={false}
         mediaCapturePermissionGrantType="grant"
+        webviewDebuggingEnabled
       />
     </View>
   );

--- a/mobile-onesdk-sample-flutter/android/app/src/main/AndroidManifest.xml
+++ b/mobile-onesdk-sample-flutter/android/app/src/main/AndroidManifest.xml
@@ -7,8 +7,7 @@
 
     <application
         android:label="F1 Flutter"
-        android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:name="${applicationName}">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/mobile-onesdk-sample-flutter/android/build.gradle
+++ b/mobile-onesdk-sample-flutter/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()

--- a/mobile-onesdk-sample-flutter/android/settings.gradle
+++ b/mobile-onesdk-sample-flutter/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "7.4.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"

--- a/mobile-onesdk-sample-flutter/lib/webview_screen.dart
+++ b/mobile-onesdk-sample-flutter/lib/webview_screen.dart
@@ -41,6 +41,7 @@ class _WebViewScreenState extends State<WebViewScreen> {
       ..setJavaScriptMode(JavaScriptMode.unrestricted);
 
     if (_controller.platform is AndroidWebViewController) {
+      AndroidWebViewController.enableDebugging(true);
       (_controller.platform as AndroidWebViewController)
           .setOnPlatformPermissionRequest(
         (PlatformWebViewPermissionRequest request) {

--- a/mobile-onesdk-sample-flutter/lib/webview_screen.dart
+++ b/mobile-onesdk-sample-flutter/lib/webview_screen.dart
@@ -38,12 +38,12 @@ class _WebViewScreenState extends State<WebViewScreen> {
   void initState() {
     super.initState();
     _controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setMediaPlaybackRequiresUserGesture(false);
+      ..setJavaScriptMode(JavaScriptMode.unrestricted);
 
     if (_controller.platform is AndroidWebViewController) {
       AndroidWebViewController.enableDebugging(true);
       final androidController = _controller.platform as AndroidWebViewController;
+      androidController.setMediaPlaybackRequiresUserGesture(false);
       androidController.setAllowFileAccess(true);
       androidController.setOnPlatformPermissionRequest(
         (PlatformWebViewPermissionRequest request) {

--- a/mobile-onesdk-sample-flutter/lib/webview_screen.dart
+++ b/mobile-onesdk-sample-flutter/lib/webview_screen.dart
@@ -43,7 +43,7 @@ class _WebViewScreenState extends State<WebViewScreen> {
     if (_controller.platform is AndroidWebViewController) {
       (_controller.platform as AndroidWebViewController)
           .setOnPlatformPermissionRequest(
-        (AndroidWebViewPermissionRequest request) {
+        (PlatformWebViewPermissionRequest request) {
           request.grant();
         },
       );

--- a/mobile-onesdk-sample-flutter/lib/webview_screen.dart
+++ b/mobile-onesdk-sample-flutter/lib/webview_screen.dart
@@ -44,7 +44,6 @@ class _WebViewScreenState extends State<WebViewScreen> {
       AndroidWebViewController.enableDebugging(true);
       final androidController = _controller.platform as AndroidWebViewController;
       androidController.setMediaPlaybackRequiresUserGesture(false);
-      androidController.setAllowFileAccess(true);
       androidController.setOnPlatformPermissionRequest(
         (PlatformWebViewPermissionRequest request) {
           request.grant();

--- a/mobile-onesdk-sample-flutter/lib/webview_screen.dart
+++ b/mobile-onesdk-sample-flutter/lib/webview_screen.dart
@@ -109,11 +109,6 @@ class _WebViewScreenState extends State<WebViewScreen> {
           : WebViewWidget(
               controller: WebViewController()
                 ..setJavaScriptMode(JavaScriptMode.unrestricted)
-                ..setOnPlatformPermissionRequest(
-                  (PlatformWebViewPermissionRequest request) {
-                    request.grant();
-                  },
-                )
                 ..loadRequest(Uri.parse(_url!)),
             ),
     );

--- a/mobile-onesdk-sample-flutter/lib/webview_screen.dart
+++ b/mobile-onesdk-sample-flutter/lib/webview_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 
@@ -51,6 +52,11 @@ class _WebViewScreenState extends State<WebViewScreen> {
       );
     }
 
+    _requestPermissionsAndFetchUrl();
+  }
+
+  Future<void> _requestPermissionsAndFetchUrl() async {
+    await [Permission.camera, Permission.microphone].request();
     _fetchUrl();
   }
 

--- a/mobile-onesdk-sample-flutter/lib/webview_screen.dart
+++ b/mobile-onesdk-sample-flutter/lib/webview_screen.dart
@@ -38,12 +38,14 @@ class _WebViewScreenState extends State<WebViewScreen> {
   void initState() {
     super.initState();
     _controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted);
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setMediaPlaybackRequiresUserGesture(false);
 
     if (_controller.platform is AndroidWebViewController) {
       AndroidWebViewController.enableDebugging(true);
-      (_controller.platform as AndroidWebViewController)
-          .setOnPlatformPermissionRequest(
+      final androidController = _controller.platform as AndroidWebViewController;
+      androidController.setAllowFileAccess(true);
+      androidController.setOnPlatformPermissionRequest(
         (PlatformWebViewPermissionRequest request) {
           request.grant();
         },

--- a/mobile-onesdk-sample-flutter/pubspec.yaml
+++ b/mobile-onesdk-sample-flutter/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   webview_flutter: ^4.4.2
   webview_flutter_android: ^3.0.0
   uuid: ^4.3.3
+  permission_handler: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/mobile-onesdk-sample-flutter/pubspec.yaml
+++ b/mobile-onesdk-sample-flutter/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
   http: ^1.2.0
   shared_preferences: ^2.2.2
-  webview_flutter: ^4.4.2
-  webview_flutter_android: ^3.0.0
+  webview_flutter: ^4.13.1
+  webview_flutter_android: ^4.7.0
   uuid: ^4.3.3
 
 dev_dependencies:

--- a/mobile-onesdk-sample-flutter/pubspec.yaml
+++ b/mobile-onesdk-sample-flutter/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
   http: ^1.2.0
   shared_preferences: ^2.2.2
-  webview_flutter: ^4.13.1
-  webview_flutter_android: ^4.7.0
+  webview_flutter: ^4.4.2
+  webview_flutter_android: ^3.0.0
   uuid: ^4.3.3
 
 dev_dependencies:

--- a/mobile-onesdk-sample-flutter/pubspec.yaml
+++ b/mobile-onesdk-sample-flutter/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   http: ^1.2.0
   shared_preferences: ^2.2.2
   webview_flutter: ^4.4.2
+  webview_flutter_android: ^3.0.0
   uuid: ^4.3.3
 
 dev_dependencies:

--- a/mobile-onesdk-sample-react-native/src/WebViewScreen.tsx
+++ b/mobile-onesdk-sample-react-native/src/WebViewScreen.tsx
@@ -102,6 +102,7 @@ export default function WebViewScreen({navigation, route}: Props) {
         domStorageEnabled
         mediaPlaybackRequiresUserAction={false}
         allowsInlineMediaPlayback
+        webviewDebuggingEnabled
       />
     </View>
   );


### PR DESCRIPTION
**Context**


**Problem**


**Solution**


**Testing Notes**


**PR Review Guidelines**
- [ ] Unit tests are added/updated
- [ ] System/Integration tests are added/updated
- [ ] Acceptance criteria is validated locally 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR primarily focuses on enabling WebView debugging across the Android, Expo, and React Native sample applications. It also refactors the Flutter sample app's WebView implementation to explicitly handle camera and microphone permissions using the `permission_handler` package and updates its build configurations.

#### Key Changes
- Enabled WebView debugging for `WebViewActivity.kt` (Android), `WebViewScreen.tsx` (Expo), and `WebViewScreen.tsx` (React Native) samples.
- In the Flutter sample, refactored `WebViewScreen` to initialize `WebViewController` earlier, explicitly request camera and microphone permissions using `permission_handler`, and grant platform permission requests directly.
- Updated Kotlin version from `1.9.10` to `1.8.22` in Flutter's `build.gradle` and `settings.gradle`.
- Added `webview_flutter_android` and `permission_handler` dependencies to Flutter's `pubspec.yaml`.
- Removed the `android:icon` attribute from the Flutter `AndroidManifest.xml`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 27 (62.8%)    |
| Churn       | 11 (25.6%)    |
| Rework      | 5 (11.6%)     |
| Total Changes | 43            |

#### Linked JIRA Issues
No issues found. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>