### PR TITLE
chore: pin GitHub Actions to immutable commit SHAs (FDEL-45965)

### DIFF
--- a/.github/workflows/mobile-flutter.yml
+++ b/.github/workflows/mobile-flutter.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295  # v2.22.0
         with:
           flutter-version: '3.19.0'
           channel: 'stable'

--- a/.github/workflows/mobile-flutter.yml
+++ b/.github/workflows/mobile-flutter.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295  # v2.22.0
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2  # v2
         with:
           flutter-version: '3.19.0'
           channel: 'stable'


### PR DESCRIPTION
## Summary
Pins third-party GitHub Actions to immutable commit SHAs as part of FDEL-45965.

## Changes
| File | Action | Old Reference | New SHA |
|---|---|---|---|
| `.github/workflows/mobile-flutter.yml` | `subosito/flutter-action` | `@v2` | `@0ca7a949...` # v2 |

## References
- JIRA: FDEL-45965
- Plan: FDEL-45965.md

> ⚠️ Do not merge until all Phase 2 PRs are reviewed and pre-flight investigations resolved.

 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a security concern by pinning a GitHub Action to an immutable commit SHA instead of a mutable tag. This is part of a broader initiative to mitigate supply chain risks by ensuring that workflows execute only vetted code.

#### Key Changes
- Updated the `subosito/flutter-action` in `mobile-flutter.yml` to use a specific commit SHA (`1a449444c387b1966244ae4d4f8c696479add0b2`) instead of the `v2` tag.
- Added an inline comment to indicate the original version (`# v2`) for readability.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Rework      | 1 (100.0%)    |
| Total Changes | 1           |

#### Linked JIRA Issues
[FDEL-45965](https://frankieone.atlassian.net/browse/FDEL-45965) - Enhance security by pinning all third-party GitHub Actions to immutable commit SHAs across the organization's repositories and settings to prevent tag-based supply chain attacks. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

[FDEL-45965]: https://frankieone.atlassian.net/browse/FDEL-45965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ