### PR TITLE
chore(deps): resolve Dependabot alerts and add supply-chain cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,32 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/frontend-onesdk-sample-angular-vite"
+      - "/frontend-onesdk-sample-angular-webpack"
+      - "/frontend-onesdk-sample-nextjs-webpack"
+      - "/frontend-onesdk-sample-react-vite"
+      - "/frontend-onesdk-sample-react-webpack"
+      - "/frontend-onesdk-sample-vanilla-react-webpack"
+      - "/frontend-onesdk-sample-vue-vite"
+      - "/frontend-onesdk-sample-vue-webpack"
+      - "/mobile-onesdk-sample-expo"
+      - "/mobile-onesdk-sample-react-native"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # Mirror the .npmrc supply-chain cooldown: don't propose versions
+    # published less than 7 days ago.
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@frankieone/*"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Supply-chain cooldown: don't install versions published less than 7 days ago.
+# Our own org's packages are exempt so internal releases aren't delayed.
+min-release-age=7
+min-release-age-exclude[]=@frankieone/*

--- a/frontend-onesdk-sample-angular-vite/package.json
+++ b/frontend-onesdk-sample-angular-vite/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^17.3.0",
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "^1.9.35",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"

--- a/frontend-onesdk-sample-angular-webpack/package.json
+++ b/frontend-onesdk-sample-angular-webpack/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^16.2.0",
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",
-    "@frankieone/one-sdk": "1.7.12",
+    "@frankieone/one-sdk": "^1.9.35",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"

--- a/frontend-onesdk-sample-nextjs-webpack/package.json
+++ b/frontend-onesdk-sample-nextjs-webpack/package.json
@@ -11,7 +11,7 @@
     "start:localServer": "npx http-server -p 8080"
   },
   "dependencies": {
-    "@frankieone/one-sdk": "^1.7.6",
+    "@frankieone/one-sdk": "^1.9.35",
     "kill-port": "^2.0.1",
     "next": "14.2.5",
     "react": "^18",

--- a/frontend-onesdk-sample-react-vite/package.json
+++ b/frontend-onesdk-sample-react-vite/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@frankieone/one-sdk": "1.7.6"
+    "@frankieone/one-sdk": "^1.9.35"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/frontend-onesdk-sample-react-webpack/package.json
+++ b/frontend-onesdk-sample-react-webpack/package.json
@@ -35,5 +35,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "react-scripts": {
+      "typescript": "^5"
+    }
   }
 }

--- a/frontend-onesdk-sample-vue-vite/package.json
+++ b/frontend-onesdk-sample-vue-vite/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "^1.9.35",
     "vue": "^3.4.29",
     "vue-router": "^4.4.0"
   },

--- a/frontend-onesdk-sample-vue-webpack/package.json
+++ b/frontend-onesdk-sample-vue-webpack/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@frankieone/one-sdk": "1.7.6",
+    "@frankieone/one-sdk": "^1.9.35",
     "core-js": "^3.8.3",
     "vue": "^3.2.13",
     "vue-router": "^4.4.0"


### PR DESCRIPTION
## What

- Bump `@frankieone/one-sdk` (`1.7.6` / `1.7.12` → `^1.9.35`) across the web samples
- Add `.npmrc` with `min-release-age=7`
- Add the **npm** ecosystem to `dependabot.yml` covering all 10 sample directories, with a matching 7-day cooldown
- Add a scoped typescript `overrides` to the `react-webpack` sample so it can be installed at all

## Why

The runtime alerts (axios ×20, dompurify ×13, next ×17, sanitize-html, react-router, form-data, uuid) were transitive dependencies of the pinned 2024 SDK releases.

`dependabot.yml` only configured `github-actions`, so npm updates were never proposed for any of the 10 samples — that's why these drifted since 2024. The new npm entry uses `directories:` to cover them all, with `cooldown.default-days: 7` mirroring the `.npmrc` and `@frankieone/*` excluded.

## Verification — every sample installed and built individually

**✅ Builds OK with `^1.9.35`**
`angular-webpack` · `nextjs-webpack` · `react-vite`

**⏸️ Not bumped — `1.9.35` regresses them, left on the old pin**

| sample | reason |
|---|---|
| `vanilla-react-webpack` | builds on the old pin; `1.9.35` fails — the SDK's ESM build uses extensionless relative imports (`./window`) that webpack 5 rejects under strict ESM resolution |
| `react-webpack` | same ESM problem, and CRA offers no way to add a `resolve` rule without ejecting |

**⚠️ Bumped, but the build was ALREADY broken on `main`** — verified against `origin/main` in a clean tree, so these are pre-existing and not caused by this PR:

| sample | pre-existing failure |
|---|---|
| `angular-vite` | Angular 17 esbuild builder has no loader for the `.woff`/`.woff2` assets the SDK imports |
| `vue-vite` | `type-check` fails, `TS7016`: no declaration file for `./MainPage.vue` and `./routes` |
| `vue-webpack` | `es5-ext` `EISDIR` under thread-loader |

The two mobile samples don't consume the npm SDK and were left alone (they're covered by the new Dependabot config).

## Follow-ups worth tracking

1. **The SDK's extensionless ESM imports affect any webpack 5 consumer** — this is the single blocker for `vanilla-react-webpack` and `react-webpack`, and it's an upstream packaging issue, not a sample issue.
2. The three pre-existing broken builds above.
3. Angular 16/17 are EOL; the remaining alerts in those samples need a major upgrade.