### PR TITLE
chore(deps): upgrade the two Angular samples to Angular 20

### DIFF
--- a/frontend-onesdk-sample-angular-vite/angular.json
+++ b/frontend-onesdk-sample-angular-vite/angular.json
@@ -27,15 +27,20 @@
             "styles": [
               "src/styles.css"
             ],
-            "scripts": []
+            "scripts": [],
+            "loader": {
+              ".svg": "file",
+              ".woff": "file",
+              ".woff2": "file"
+            }
           },
           "configurations": {
             "production": {
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "1500kb",
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",
@@ -97,8 +102,5 @@
         }
       }
     }
-  },
-  "cli": {
-    "analytics": false
   }
 }

--- a/frontend-onesdk-sample-angular-vite/package.json
+++ b/frontend-onesdk-sample-angular-vite/package.json
@@ -10,23 +10,23 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^17.3.0",
-    "@angular/common": "^17.3.0",
-    "@angular/compiler": "^17.3.0",
-    "@angular/core": "^17.3.0",
-    "@angular/forms": "^17.3.0",
-    "@angular/platform-browser": "^17.3.0",
-    "@angular/platform-browser-dynamic": "^17.3.0",
-    "@angular/router": "^17.3.0",
+    "@angular/animations": "^20.3.0",
+    "@angular/common": "^20.3.0",
+    "@angular/compiler": "^20.3.0",
+    "@angular/core": "^20.3.0",
+    "@angular/forms": "^20.3.0",
+    "@angular/platform-browser": "^20.3.0",
+    "@angular/platform-browser-dynamic": "^20.3.0",
+    "@angular/router": "^20.3.0",
     "@frankieone/one-sdk": "^1.9.35",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.14.3"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.3.8",
-    "@angular/cli": "^17.3.8",
-    "@angular/compiler-cli": "^17.3.0",
+    "@angular-devkit/build-angular": "^20.3.0",
+    "@angular/cli": "^20.3.0",
+    "@angular/compiler-cli": "^20.3.0",
     "@types/jasmine": "~5.1.0",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",
@@ -34,6 +34,10 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.8.3"
+  },
+  "overrides": {
+    "uuid@<11.1.1": "^11.1.1",
+    "webpack-dev-server@<5.2.6": "^5.2.6"
   }
 }

--- a/frontend-onesdk-sample-angular-webpack/angular.json
+++ b/frontend-onesdk-sample-angular-webpack/angular.json
@@ -124,8 +124,5 @@
         }
       }
     }
-  },
-  "cli": {
-    "analytics": false
   }
 }

--- a/frontend-onesdk-sample-angular-webpack/package.json
+++ b/frontend-onesdk-sample-angular-webpack/package.json
@@ -10,26 +10,27 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^16.2.0",
-    "@angular/common": "^16.2.0",
-    "@angular/compiler": "^16.2.0",
-    "@angular/core": "^16.2.0",
-    "@angular/forms": "^16.2.0",
-    "@angular/platform-browser": "^16.2.0",
-    "@angular/platform-browser-dynamic": "^16.2.0",
-    "@angular/router": "^16.2.0",
+    "@angular/animations": "^20.3.0",
+    "@angular/common": "^20.3.0",
+    "@angular/compiler": "^20.3.0",
+    "@angular/core": "^20.3.0",
+    "@angular/forms": "^20.3.0",
+    "@angular/platform-browser": "^20.3.0",
+    "@angular/platform-browser-dynamic": "^20.3.0",
+    "@angular/router": "^20.3.0",
     "@frankieone/one-sdk": "^1.9.35",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.13.0"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-builders/custom-webpack": "^16.0.1",
-    "@angular-devkit/build-angular": "^16.2.14",
-    "@angular/cli": "^16.2.14",
-    "@angular/compiler-cli": "^16.2.0",
+    "@angular-builders/custom-webpack": "^20.0.0",
+    "@angular-devkit/build-angular": "^20.3.0",
+    "@angular/cli": "^20.3.0",
+    "@angular/compiler-cli": "^20.3.0",
     "@types/jasmine": "~4.3.0",
     "@types/react": "^18.3.3",
+    "css-loader": "^7.1.2",
     "file-loader": "^6.2.0",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
@@ -38,6 +39,10 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "style-loader": "^4.0.0",
-    "typescript": "~5.1.3"
+    "typescript": "~5.8.3"
+  },
+  "overrides": {
+    "uuid@<11.1.1": "^11.1.1",
+    "webpack-dev-server@<5.2.6": "^5.2.6"
   }
 }

--- a/frontend-onesdk-sample-angular-webpack/src/app/app.component.ts
+++ b/frontend-onesdk-sample-angular-webpack/src/app/app.component.ts
@@ -2,6 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
+	// Angular 19 made `standalone: true` the default. AppComponent is declared
+	// in (and bootstrapped by) AppModule, and its template relies on *ngFor,
+	// routerLink and router-outlet coming from BrowserModule/AppRoutingModule,
+	// so it stays non-standalone. The routed components are standalone and use
+	// no Angular directives, so they need no imports of their own.
+	standalone: false,
 	selector: 'app-root',
 	templateUrl: './app.component.html',
 	styleUrls: ['./app.component.css']

--- a/frontend-onesdk-sample-angular-webpack/webpack.config.js
+++ b/frontend-onesdk-sample-angular-webpack/webpack.config.js
@@ -1,25 +1,23 @@
-module.exports = {
-	module: {
-		rules: [
-			{
-				test: /\.svg$/,
-				use: [
-					{
-						loader: 'file-loader',
-						options: {
-							name: 'assets/[name].[hash:8].[ext]'
-						}
-					}
-				]
-			},
-			{
-				test: /\.css$/,
-				use: [
-					{ loader: 'style-loader' },
-					{ loader: 'css-loader' }
-				],
-				exclude: /src/
-			}
-		]
-	}
-}
+module.exports = (config) => {
+	// @frankieone/one-sdk's ESM build imports .css and .svg files directly from
+	// node_modules. Angular's own style rules are scoped to the app's `styles`
+	// option and component styles, so nothing matches these and webpack errors
+	// with "no loaders are configured to process this file".
+	//
+	// Prepending (rather than appending) matters: Angular groups its style
+	// handling under `oneOf`, and these rules have to be reachable before that.
+	config.module.rules.unshift(
+		{
+			test: /\.css$/,
+			include: /node_modules[\\/]@frankieone[\\/]one-sdk/,
+			use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
+		},
+		{
+			test: /\.(svg|woff2?)$/,
+			include: /node_modules[\\/]@frankieone[\\/]one-sdk/,
+			type: 'asset/resource',
+			generator: { filename: 'assets/[name].[hash:8][ext]' },
+		},
+	);
+	return config;
+};


### PR DESCRIPTION
chore(deps): upgrade the two Angular samples to Angular 20

Resolves all 36 open Dependabot alerts in this repo. Every one of them is Angular
(`@angular/core`, `@angular/compiler`, `@angular/common`) in the two nested sample apps.

## Why this needs a major upgrade

The advisories have **no fix on the installed lines**:

    @angular/core <= 19.2.25   -> first_patched_version: null
    @angular/core <= 18.2.14   -> first_patched_version: null

Angular 18 and 19 are end-of-life; the fixes exist only from **20.3.27** onward (and 21.2.19 /
22.0.1). The samples were on Angular **17** (vite) and **16** (webpack), so there is no patch
release to move to - it has to be Angular 20.

## What changed

- `frontend-onesdk-sample-angular-vite`: `package.json`, `angular.json`
- `frontend-onesdk-sample-angular-webpack`: `package.json`, `angular.json`,
  `webpack.config.js`, `src/app/app.component.ts`

These are ported verbatim from the standalone repos, where the same upgrade is **already
merged and running**:

- `frankieone/frontend-onesdk-sample-angular-vite` #37
- `frankieone/frontend-onesdk-sample-angular-webpack` #35

Both standalone repos now report **zero Angular alerts**, which is the evidence that `^20.3.0`
satisfies these advisories. I checked before porting that the nested copies and the standalone
repos have identical dependency sets and scripts, so the only deltas are the versions plus the
fixes below.

The non-obvious parts of that upgrade, for reviewers:

- **webpack sample** - `webpack.config.js` becomes a function and uses
  `config.module.rules.unshift(...)`. Prepending matters: Angular groups its style rules under
  `oneOf`, so an appended rule never matches. `css-loader` is added as an explicit dependency.
- **webpack sample** - `app.component.ts` gets `standalone: false`. Angular 19+ made components
  standalone by default, so without it the build fails with NG6008.
- **vite sample** - `angular.json` gains a `loader` mapping for `.svg`/`.woff`/`.woff2` (the
  Angular 18+ application builder needs it) and a raised initial bundle budget.

## Verification

Both apps install and build cleanly from scratch:

    angular-vite     npm install: ok    npm run build: ok
    angular-webpack  npm install: ok    npm run build: ok

`@angular/core` resolves to **20.3.29** in both, above the 20.3.27 the advisories require.

The webpack build emits a bundle-budget *warning* (1.37 MB vs a 1.00 MB budget). It is a
warning, not an error, and matches the behaviour of the already-merged standalone repo, so I
have left the budget alone rather than tuning it here.

Neither sample has a lockfile, so this is a manifest-only change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the Angular dependencies across two sample projects (Vite and Webpack variants) to Angular 20, along with upgrading TypeScript and related build toolchain dependencies. It also updates webpack configuration and component settings to ensure compatibility with Angular 20 build changes.

#### Key Changes
- Upgraded Angular framework packages (`@angular/core`, `@angular/cli`, `@angular-devkit/build-angular`, etc.) to `^20.3.0` in both Vite and Webpack sample applications.
- Updated TypeScript to `~5.8.3` and `zone.js` to `~0.15.0`.
- Explicitly defined `standalone: false` on `AppComponent` in the Webpack sample to maintain compatibility with `AppModule` declaration defaults introduced in Angular 19+.
- Refactored `webpack.config.js` and `angular.json` loader rules for processing CSS, SVG, and font assets from `@frankieone/one-sdk`.
- Adjusted initial budget limits in `angular.json` for the Vite sample.
- Added dependency overrides for `uuid` and `webpack-dev-server`.

#### Work Breakdown

| Category | Lines Changed |
| --- | --- |
| New Work | 20 (24.7%) |
| Churn | 8 (9.9%) |
| Refactor | 53 (65.4%) |
| Total Changes | 81 |

#### Linked JIRA Issues
No issues found. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>